### PR TITLE
PBOOK-86: EditButtonIsBackInViewMode

### DIFF
--- a/src/main/java/edu/wisc/my/portlets/bookmarks/web/ViewBookmarksController.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/web/ViewBookmarksController.java
@@ -34,7 +34,11 @@ import javax.portlet.RenderResponse;
 import org.springframework.web.portlet.ModelAndView;
 import org.springframework.web.portlet.mvc.AbstractController;
 
+import edu.wisc.my.portlets.bookmarks.domain.Bookmark;
 import edu.wisc.my.portlets.bookmarks.domain.BookmarkSet;
+import edu.wisc.my.portlets.bookmarks.domain.CollectionFolder;
+import edu.wisc.my.portlets.bookmarks.domain.Folder;
+import edu.wisc.my.portlets.bookmarks.domain.Preferences;
 import edu.wisc.my.portlets.bookmarks.web.support.BookmarkSetRequestResolver;
 import edu.wisc.my.portlets.bookmarks.web.support.PreferencesRequestResolver;
 import edu.wisc.my.portlets.bookmarks.web.support.ViewConstants;
@@ -86,8 +90,26 @@ public class ViewBookmarksController extends AbstractController {
     @Override
     protected ModelAndView handleRenderRequestInternal(RenderRequest request, RenderResponse response) throws Exception {
         final BookmarkSet bookmarkSet = this.bookmarkSetRequestResolver.getBookmarkSet(request, false);
+        final Preferences preferences = this.preferencesRequestResolver.getPreferences(request, false);
         final Map<String, Object> refData = new HashMap<String, Object>();
         refData.put(ViewConstants.BOOKMARK_SET, bookmarkSet);
+        if (preferences != null) {      
+                    refData.put(ViewConstants.OPTIONS, preferences);       
+                }      
+                else {     
+                    refData.put(ViewConstants.OPTIONS, new Preferences());     
+                }      
+              
+               refData.put(ViewConstants.COMMAND_EMPTY_BOOKMARK, new Bookmark());     
+               refData.put(ViewConstants.COMMAND_EMPTY_FOLDER, new Folder());     
+               refData.put(ViewConstants.COMMAND_AVAILABLE_COLLECTIONS, this.availableCollections);       
+               refData.put(ViewConstants.COMMAND_EMPTY_COLLECTION, new CollectionFolder());       
+                      
+                if (request.getRemoteUser() == null) {     
+                   refData.put("guestMode", true);     
+                } else {       
+                   refData.put("guestMode", false);
+                }
         return new ModelAndView("viewBookmarks", refData);
     }
 

--- a/src/main/webapp/WEB-INF/jsp/viewBookmarks.jsp
+++ b/src/main/webapp/WEB-INF/jsp/viewBookmarks.jsp
@@ -20,6 +20,63 @@
 --%>
 <%@ include file="/WEB-INF/jsp/include.jsp" %>
 <div class="bookmarksPortlet">
+<script type="text/javascript">
+        new BookmarksPortletData(   "${portletNamespace}",      //namespace
+                                    "newWindow",                //bookmark_form_newWindow
+                                    "url",                      //bookmark_form_url
+                                    "emptyBookmarkForm",        //bookmark_forms_empty
+                                    "errorBookmarkForm",        //bookmark_forms_error
+                                    "url_",                     //bookmark_reference_url
+                                    "bookmarksTreeAndForm",     //bookmarksTreeAndForm
+                                    "bookmarksChildFolder_",    //entry_childFolderPrefix
+                                    "cancelLink",               //entry_edit_cancelLink
+                                    "editLink",                 //entry_edit_editLine
+                                   "action",                   //entry_form_action
+                                    "editBookmark",             //entry_form_action_editBookmar
+                                    "editFolder",               //entry_form_action_editFolder
+                                    "editCollection",           //entry_form_action_editCollection
+                                    "newBookmark",              //entry_form_action_newBookmark
+                                    "newFolder",                //entry_form_action_newFolder
+                                    "newCollection",            //entry_form_action_newCollection
+                                    "folderPath",               //entry_form_folderPath
+                                    "folderActionLabel",        //entry_form_folderPathLabel
+                                    "idPath",                   //entry_form_idPath
+                                    "name",                     //entry_form_name
+                                    "note",                     //entry_form_note
+                                    "entryImg_",                //entry_imagePrefix
+                                    "referenceFolderPath",      //entry_reference_folderPath
+                                    "name_",                    //entry_reference_name
+                                    "note_",                    //entry_reference_note
+                                    "emptyFolderForm",          //folder_forms_empty
+                                    "errorFolderForm",          //folder_forms_error
+                                    "/img/folder-closed.gif",   //folder_image_closed
+                                    "/img/folder-opened.gif",   //folder_image_open
+                                    "url",                      //collection_form_url
+                                    "emptyCollectionForm",      //collection_forms_empty
+                                    "errorCollectionForm",      //collection_forms_error
+                                    "optionsForm",         //options_form
+                                    "optionsLink",              //options_showLink
+                                    "<spring:message code="portlet.script.folder.create" javaScriptEscape="true"/>",                    //messages_folder_create
+                                    "<spring:message code="portlet.script.folder.move" javaScriptEscape="true"/>",                      //messages_folder_move
+                                    "<spring:message code="portlet.script.delete.confirm.bookmark.prefix" javaScriptEscape="true"/>",   //messages_delete_bookmark_prefix
+                                    "<spring:message code="portlet.script.delete.confirm.bookmark.suffix" javaScriptEscape="true"/>",   //messages_delete_bookmark_suffix
+                                    "<spring:message code="portlet.script.delete.confirm.collection.prefix" javaScriptEscape="true"/>",     //messages_delete_collection_prefix
+                                    "<spring:message code="portlet.script.delete.confirm.collection.suffix" javaScriptEscape="true"/>",    //messages_delete_collection_suffix
+                                    "<spring:message code="portlet.script.delete.confirm.folder.prefix" javaScriptEscape="true"/>",     //messages_delete_folder_prefix
+                                    "<spring:message code="portlet.script.delete.confirm.folder.suffix" javaScriptEscape="true"/>");    //messages_delete_folder_suffix
+    </script>
+    
+    <c:set var="optionsFormHidden" value="true"/>
+    <c:if test="${hasErrors && empty folderCommand && empty bookmarkCommand}">
+        <c:set var="optionsFormHidden" value="false"/>
+        <c:set var="optionsLinkClass" value="bookmark-hide" scope="page"/>
+        <c:set var="bookmarksTreeAndFormClass" value="bookmark-hide" scope="page"/>
+    </c:if>
+
+    <div style="float: right; ${ guestMode ? 'display: none;' : '' }">
+        <button type="button" id="${portletNamespace}optionsLink" class="btn btn-default ${optionsLinkClass}" onclick="showOptionsForm('${portletNamespace}');return false;"><spring:message code="portlet.view.options"/></button>
+    </div>
+    <bm:optionsForm formName="optionsForm" commandName="options" hidden="${optionsFormHidden}" namespace="${portletNamespace}"/>
     <div id="${portletNamespace}bookmarksTreeAndForm">
         <c:set var="bookmarkEntries" value="${bookmarkSet.sortedChildren}" scope="page"/>
         <c:choose>
@@ -36,5 +93,64 @@
                 </div>
             </c:otherwise>
         </c:choose>
+        <br>
+        <c:if test="${!guestMode }">
+            <button type="button" onclick="newBookmark('${portletNamespace}');return false;" class="btn btn-default jsTextLink portlet-form-label" style="${ guestMode ? 'display: none;' : '' }"><spring:message code="portlet.view.addBookmark"/></button>
+            &nbsp;&nbsp;&nbsp;
+            <button type="button" onclick="newFolder('${portletNamespace}');return false;" class="btn btn-default jsTextLink portlet-form-label" style="${ guestMode ? 'display: none;' : '' }"><spring:message code="portlet.view.addFolder"/></button>
+            &nbsp;&nbsp;&nbsp;
+            <button type="button" onclick="newCollection('${portletNamespace}');return false;" class="btn btn-default jsTextLink portlet-form-label" style="${ fn:length(availableCollections) > 0 and !guestMode ? '' : 'display: none;' }"><spring:message code="portlet.view.addCollection"/></button>
+            <portlet:renderURL portletMode="EDIT" var="EditModeUrl" />
+            <a type="button" class="btn btn-default" href="${EditModeUrl}"><spring:message
+                code="portlet.view.edit.show"
+                text="Show Edit"/>
+            </a>
+            <br>
+        </c:if>
+        <c:if test="${hasErrors}">
+            <c:choose>
+                <c:when test="${fn:startsWith(param['action'], 'new')}">
+                    <spring:message code="portlet.script.folder.create" javaScriptEscape="false" var="folderActionLabel"/>
+                </c:when>
+                <c:when test="${fn:startsWith(param['action'], 'edit')}">
+                    <spring:message code="portlet.script.folder.move" javaScriptEscape="false" var="folderActionLabel"/>
+                </c:when>
+            </c:choose>
+        </c:if>
+
+        <c:if test="${hasErrors && !empty bookmarkCommand}">
+            <bm:bookmarkForm 
+                formName="errorBookmarkForm" commandName="bookmarkCommand" entries="${bookmarkEntries}" 
+                hidden="false" namespace="${portletNamespace}" actionInput="${param['action']}" 
+                idPathInput="${param['idPath']}" folderActionLabel="${folderActionLabel}" isErrorForm="true"/>
+
+            <script type="text/javascript">
+                setupErrorForm("${portletNamespace}", "errorBookmarkForm", "${param['folderPath']}");
+            </script>
+        </c:if>
+        <bm:bookmarkForm formName="emptyBookmarkForm" commandName="emptyBookmarkCommand" entries="${bookmarkEntries}" hidden="true" namespace="${portletNamespace}"/> 
+
+        <c:if test="${hasErrors && !empty folderCommand}">
+            <bm:folderForm 
+                formName="errorFolderForm" commandName="folderCommand" entries="${bookmarkEntries}" 
+                hidden="false" namespace="${portletNamespace}" actionInput="${param['action']}" 
+                idPathInput="${param['idPath']}" folderActionLabel="${folderActionLabel}" isErrorForm="true"/>
+            <script type="text/javascript">
+                setupErrorForm("${portletNamespace}", "errorFolderForm", "${param['folderPath']}");
+            </script>
+        </c:if>
+        <bm:folderForm formName="emptyFolderForm" commandName="emptyFolderCommand" entries="${bookmarkEntries}" hidden="true" namespace="${portletNamespace}"/>
+
+        <c:if test="${hasErrors && !empty collectionCommand}">
+            <bm:collectionForm 
+                formName="errorCollectionForm" commandName="collectionCommand" entries="${bookmarkEntries}" 
+                hidden="false" namespace="${portletNamespace}" actionInput="${param['action']}" 
+                idPathInput="${param['idPath']}" folderActionLabel="${folderActionLabel}" isErrorForm="true"/>
+
+            <script type="text/javascript">
+                setupErrorForm("${portletNamespace}", "errorCollectionForm", "${param['folderPath']}");
+            </script>
+        </c:if>
+        <bm:collectionForm formName="emptyCollectionForm" commandName="emptyCollectionCommand" entries="${bookmarkEntries}" hidden="true" namespace="${portletNamespace}"/> 
     </div>
 </div>

--- a/src/main/webapp/WEB-INF/tags/bm/bookmarkForm.tag
+++ b/src/main/webapp/WEB-INF/tags/bm/bookmarkForm.tag
@@ -30,7 +30,7 @@ For the errors
     <c:set var="folderActionLabel"><spring:message code="portlet.entry.form.folder"/></c:set>
 </c:if>
 
-<portlet:actionURL var="formUrl"/>
+<portlet:actionURL portletMode="EDIT" var="formUrl"/>
 <form:form id="${namespace}${formName}" name="${namespace}${formName}" method="post" action="${formUrl}" commandName="${commandName}" cssClass="${formClass}">
     <input name="action" type="hidden" value="${actionInput}"/>
     <input name="idPath" type="hidden" value="${idPathInput}"/>

--- a/src/main/webapp/WEB-INF/tags/bm/collectionForm.tag
+++ b/src/main/webapp/WEB-INF/tags/bm/collectionForm.tag
@@ -30,7 +30,7 @@ For the errors
     <c:set var="folderActionLabel"><spring:message code="portlet.entry.form.folder"/></c:set>
 </c:if>
 
-<portlet:actionURL var="formUrl"/>
+<portlet:actionURL portletMode="EDIT" var="formUrl"/>
 <form:form id="${namespace}${formName}" name="${namespace}${formName}" method="post" action="${formUrl}" commandName="${commandName}" cssClass="${formClass}">
     <input name="action" type="hidden" value="${actionInput}"/>
     <input name="idPath" type="hidden" value="${idPathInput}"/>

--- a/src/main/webapp/WEB-INF/tags/bm/folderForm.tag
+++ b/src/main/webapp/WEB-INF/tags/bm/folderForm.tag
@@ -29,7 +29,7 @@ For the errors
     <c:set var="folderActionLabel"><spring:message code="portlet.entry.form.folder"/></c:set>
 </c:if>
 
-<portlet:actionURL var="formUrl"/>
+<portlet:actionURL portletMode="EDIT" var="formUrl"/>
 <form:form id="${namespace}${formName}" name="${namespace}${formName}" method="post" action="${formUrl}" commandName="${commandName}" cssClass="${formClass}">
     <input name="action" type="hidden" value="${actionInput}"/>
     <input name="idPath" type="hidden" value="${idPathInput}"/>

--- a/src/main/webapp/WEB-INF/tags/bm/optionsForm.tag
+++ b/src/main/webapp/WEB-INF/tags/bm/optionsForm.tag
@@ -14,9 +14,9 @@
     <c:set var="formClass" value="bookmark-hide" scope="page"/>
 </c:if>
 
-<portlet:actionURL var="formUrl"/>
-<h3><spring:message code="portlet.edit.mode" text="Edit Mode"/></h3>
+<portlet:actionURL portletMode="EDIT" var="formUrl"/>
 <form:form id="${namespace}${formName}" name="${namespace}${formName}" method="post" action="${formUrl}" commandName="${commandName}" cssClass="${formClass}">
+    <h3><spring:message code="portlet.edit.mode" text="Edit Mode"/></h3>
 	<input name="action" type="hidden" value="saveOptions"/>
 	<fieldset>
 		<legend><spring:message code="portlet.options.form.defaultFolderOperations.title"/></legend>

--- a/src/main/webapp/css/bookmarks.css
+++ b/src/main/webapp/css/bookmarks.css
@@ -16,6 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+ .bookmarksPortlet ul{
+    display: block;
+ }
+ 
 .bookmarksPortlet ul.bookmarkList {
     list-style-type: none !important;
     margin: 0;


### PR DESCRIPTION
After push back from users using the latest release, we've learned that the contextual edit button to go into edit mode did not work for most users.  They were lost and confused.

This brings back the edit button on the view mode (just goes to edit mode) and the 'add bookmark' and 'add folder' buttons to the view mode.

Before:
![before](https://cloud.githubusercontent.com/assets/5521429/5637575/b11d3360-95c2-11e4-8c89-287954f186f7.gif)

After:
![after](https://cloud.githubusercontent.com/assets/5521429/5637614/2587de94-95c3-11e4-9f01-3d057812bb03.gif)
