### PR TITLE
PBOOK-88 Updated Spring to 3.2.13, Hibernate to 3.6.10, Java to 1.7.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,10 @@
         <system>${jasig-issues-system}</system>
     </issueManagement>
 
+    <properties>
+        <spring.version>3.2.13.RELEASE</spring.version>
+    </properties>
+
     <dependencies>
 
         <!-- ===== Compile Time Dependencies ============================== -->
@@ -86,10 +90,8 @@
 
         <dependency>
             <groupId>org.hibernate</groupId>
-            <artifactId>hibernate</artifactId>
-            <version>3.2.3.ga</version>
-            <type>jar</type>
-            <scope>compile</scope>
+            <artifactId>hibernate-core</artifactId>
+            <version>3.6.10.Final</version>
         </dependency>
 
         <dependency>
@@ -110,64 +112,32 @@
 
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>2.0.5</version>
-            <type>jar</type>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-dao</artifactId>
-            <version>2.0.5</version>
-            <type>jar</type>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-hibernate3</artifactId>
-            <version>2.0.8</version>
-            <type>jar</type>
-            <scope>compile</scope>
+            <artifactId>spring-core</artifactId>
+            <version>${spring.version}</version>
         </dependency>
         
+        <dependency>
+	        <groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<version>${spring.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc-portlet</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-orm</artifactId>
+            <version>${spring.version}</version>
+        </dependency>        
+
         <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>jta</artifactId>
             <version>1.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jmx</artifactId>
-            <version>2.0.5</version>
-            <type>jar</type>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-portlet</artifactId>
-            <version>2.0.5</version>
-            <type>jar</type>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-webmvc</artifactId>
-            <version>2.0.5</version>
-            <type>jar</type>
-            <scope>compile</scope>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-aop</artifactId>
-            <version>2.0.5</version>
-            <type>jar</type>
-            <scope>compile</scope>
         </dependency>
         
         <dependency>
@@ -191,10 +161,22 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.14</version>
+            <version>1.2.17</version>
             <type>jar</type>
             <scope>runtime</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>net.sf.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+
+		<dependency>
+		    <groupId>net.sf.ehcache</groupId>
+		    <artifactId>ehcache-web</artifactId>
+		    <version>2.0.4</version>
+		</dependency>
 
         <!-- ===== Provided Dependencies ================================== -->
         <dependency>
@@ -217,7 +199,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.2</version>
+            <version>4.12</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>
@@ -230,8 +212,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -33,7 +33,8 @@
         <property name="hibernate.jdbc.batch_size">32</property>
         <property name="hibernate.jdbc.batch_versioned_data">true</property>
         
-        <property name="hibernate.cache.provider_class">org.hibernate.cache.EhCacheProvider</property>
+        <property name="hibernate.cache.use_second_level_cache">true</property>
+        <property name="hibernate.cache.provider_class">net.sf.ehcache.hibernate.SingletonEhCacheProvider</property>
         <property name="hibernate.cache.use_query_cache">true</property>
         
         <property name="hibernate.current_session_context_class">thread</property>


### PR DESCRIPTION
Also added ehcache dependency and updated hibernate config to use the newer version.

Please note, the spring SimpleFormController was deprecated in Spring 3 and removed in favor of annotation based controllers in Spring 4. Therefore, further upgrades to newer releases of Spring will require re-work of the code base.