### PR TITLE
docs(readme): add maven badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Bookmarks Portlet
 
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.jasig.portlet/BookmarksPortlet/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.jasig.portlet/BookmarksPortlet)
 [![Linux Build Status](https://travis-ci.org/Jasig/BookmarksPortlet.svg?branch=master)](https://travis-ci.org/Jasig/BookmarksPortlet)
 [![Windows Build status](https://ci.appveyor.com/api/projects/status/xlfow471pvwbyp5n/branch/master?svg=true)](https://ci.appveyor.com/project/ChristianMurphy/bookmarksportlet/branch/master)
 


### PR DESCRIPTION
Give at-a-glance knowledge of:
* latest version number
* that this is available from maven central
* link to documentation on inclusion for maven, gradle, etc