### PR TITLE
#24 wrapped the request in a POST form

### DIFF
--- a/src/main/webapp/WEB-INF/tags/bm/treeEntries.tag
+++ b/src/main/webapp/WEB-INF/tags/bm/treeEntries.tag
@@ -33,12 +33,7 @@
 
 <c:forEach items="${entries}" var="bookmarkEntry">
     <c:set var="entryIdPath" value="${parentIdPath}.${bookmarkEntry.id}"/>
-   
-    <portlet:actionURL var="deleteEntryUrl">
-        <portlet:param name="action" value="deleteEntry"/>
-        <portlet:param name="entryIndex" value="${entryIdPath}"/>
-    </portlet:actionURL>
-    
+
     <%-- Need to zero out page scoped parameters since they seem to be scoped to more than just the .tag file --%>
     <c:set var="entryUrlOnClick"/>
     <c:set var="folderImgSufix"/>
@@ -142,10 +137,14 @@
 	        <span id="${namespace}entryEditButtons" name="${namespace}entryEditButtons" >
 	            <a href="javascript:void(0);" onclick="editEntry('${namespace}', '${entryType}', '${parentIdPath}', '${entryIdPath}');return false;"
 	                title="${entryEditText}"><img src="${pageContext.request.contextPath}/img/edit.gif" alt="${entryEditText}"/></a>
-	            
-	            <a href="javascript:void(0);"
-	                onclick="deleteEntry('${namespace}', '${entryType}', '${entryIdPath}', '${deleteEntryUrl}');return false;" 
-	                title="${entryDeleteText}"><img src="${pageContext.request.contextPath}/img/delete.gif" alt="${entryDeleteText}"/></a>
+
+	            <form action="<portlet:actionURL escapeXml="false"></portlet:actionURL>" method="post" style="display: inline-block">
+	                <input type="hidden" name="action" value="deleteEntry"/>
+	                <input type="hidden" name="entryIndex" value="${entryIdPath}"/>
+	                <button type="submit" class="btn btn-link btn-unpadded">
+	                    <img src="${pageContext.request.contextPath}/img/delete.gif" alt="${entryDeleteText}"/>
+	                </button>
+	            </form>
 	        </span>
         </c:if>
 

--- a/src/main/webapp/WEB-INF/tags/bm/treeEntries.tag
+++ b/src/main/webapp/WEB-INF/tags/bm/treeEntries.tag
@@ -138,7 +138,7 @@
 	            <a href="javascript:void(0);" onclick="editEntry('${namespace}', '${entryType}', '${parentIdPath}', '${entryIdPath}');return false;"
 	                title="${entryEditText}"><img src="${pageContext.request.contextPath}/img/edit.gif" alt="${entryEditText}"/></a>
 
-	            <form action="<portlet:actionURL escapeXml="false"></portlet:actionURL>" method="post" style="display: inline-block">
+	            <form action="<portlet:actionURL escapeXml="false"></portlet:actionURL>" method="post" style="display: inline-block" onSubmit="return deleteEntry('${namespace}', '${entryType}', '${entryIdPath}');">
 	                <input type="hidden" name="action" value="deleteEntry"/>
 	                <input type="hidden" name="entryIndex" value="${entryIdPath}"/>
 	                <button type="submit" class="btn btn-link btn-unpadded">

--- a/src/main/webapp/css/bookmarks.css
+++ b/src/main/webapp/css/bookmarks.css
@@ -52,3 +52,6 @@
     visibility: visible;
     display: none;
 }
+.bookmarksPortlet .btn-unpadded {
+    padding: 0
+}

--- a/src/main/webapp/script/bookmarks.js
+++ b/src/main/webapp/script/bookmarks.js
@@ -320,7 +320,7 @@ function editCollection(namespace, parentIdPath, entryIdPath) {
     showForm(namespace, bookmarkPortletsData[namespace].collection_forms_empty);
 }
 
-function deleteEntry(namespace, type, entryIdPath, deleteUrl) {
+function deleteEntry(namespace, type, entryIdPath) {
     var confirmMessage = "";
     var name = getNamespacedElement(namespace, bookmarkPortletsData[namespace].entry_reference_name + entryIdPath).innerHTML;
 
@@ -339,10 +339,7 @@ function deleteEntry(namespace, type, entryIdPath, deleteUrl) {
         confirmMessage = confirmMessage + bookmarkPortletsData[namespace].messages_delete_collection_suffix;    
     }
 
-    var shouldDelete = confirm(confirmMessage);
-    if (shouldDelete) {
-        window.location = deleteUrl;
-    }
+    return confirm(confirmMessage);
 }
 
 function setupErrorForm(namespace, formName, parentIdPath) {


### PR DESCRIPTION
For issue #24 

Confirmed in IE 11, Edge, FF, and Chrome.

The dev tools on IE 11 and Edge aren't showing the parameters, and Edge's dev tools still thinks it's a GET request, but the uP logs are showing it as a POST, and the bookmark / folder is deleted as expected.