### PR TITLE
chore: migrate jasig-parent → uportal-portlet-parent:46

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <parent>
-    <groupId>org.jasig.parent</groupId>
-    <artifactId>jasig-parent</artifactId>
-    <version>41</version>
+    <groupId>org.jasig.portlet</groupId>
+    <artifactId>uportal-portlet-parent</artifactId>
+    <version>46</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -246,12 +246,13 @@
       </exclusions>
     </dependency>
 
-    <!-- ===== Provided Dependencies ================================== -->
+    <!-- ===== Provided Dependencies ==================================
+      | Version inherited from uportal-portlet-parent's
+      | dependencyManagement; do not pin locally.
+    +-->
     <dependency>
       <groupId>javax.portlet</groupId>
       <artifactId>portlet-api</artifactId>
-      <version>2.0</version>
-      <type>jar</type>
       <scope>provided</scope>
     </dependency>
 
@@ -268,15 +269,7 @@
   <build>
     <finalName>BookmarksPortlet</finalName>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
-        <configuration>
-          <source>11</source>
-          <target>11</target>
-        </configuration>
-      </plugin>
+      <!-- maven-compiler-plugin (source/target Java 11) inherited from uportal-portlet-parent -->
       <plugin>
         <groupId>net.sf.alchim</groupId>
         <artifactId>yuicompressor-maven-plugin</artifactId>


### PR DESCRIPTION
Consume the newly-released `uportal-portlet-parent:44` instead of the old `org.jasig.parent:jasig-parent:41`. One-line `<parent>` bump.

### What v44 brings

- Central Publisher Portal `<distributionManagement>` (replaces the dead `oss.sonatype.org` URLs that were sunset June 2025)
- `<developers>` block required for Central Portal validation
- Java 11 compiler default
- Drops the unmaintained `org.sonatype.oss:oss-parent:9` inheritance

Part of the ecosystem-wide sweep. Validated with `mvn help:effective-pom -N`.

Parent release: uPortal-Project/uportal-portlet-parent#7