### PR TITLE
chore: bump uportal-portlet-parent 46 → 47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>46</version>
+    <version>47</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -50,8 +50,8 @@
   </issueManagement>
 
   <properties>
+    <!-- Override parent's logback 1.3.12; this portlet tracks logback 1.5.x. -->
     <logbackVersion>1.5.16</logbackVersion>
-    <slf4jVersion>2.0.16</slf4jVersion>
     <spring.version>4.3.30.RELEASE</spring.version>
     <uportal-libs.version>5.17.0</uportal-libs.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
@@ -64,12 +64,10 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4jVersion}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>${slf4jVersion}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -99,9 +97,6 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
-      <type>jar</type>
-      <scope>compile</scope>
     </dependency>
 
     <dependency>
@@ -119,23 +114,16 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
-      <version>1.1.2</version>
-      <type>jar</type>
-      <scope>compile</scope>
     </dependency>
 
     <dependency>
       <groupId>taglibs</groupId>
       <artifactId>standard</artifactId>
-      <version>1.1.2</version>
-      <type>jar</type>
-      <scope>compile</scope>
     </dependency>
 
       <dependency>
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
-          <version>1.3.2</version>
       </dependency>
 
       <dependency>
@@ -260,8 +248,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <type>jar</type>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -320,7 +306,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.3.2</version>
         <dependencies>
           <dependency>
             <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
## Summary

Parent v47 promoted common deps to `<dependencyManagement>`. Drop the now-redundant per-project pins.

**Inherited from parent dM now:** slf4j-api, jcl-over-slf4j, commons-lang, jstl, taglibs:standard, javax.annotation-api, junit.

**Retained local overrides:**
- logback-classic at 1.5.16 (parent is 1.3.12, portlet tracks logback 1.5.x)
- commons-httpclient 3.1, hibernate-core/validator, spring 4.3.30, ehcache 2.10.9.2 + ehcache-web — distinct artifacts from what parent has

**Plugins:** maven-war-plugin drops its local 3.3.2 pin; inherits parent's 3.4.0. The plexus-archiver plugin-scoped dep stays (plugin deps don't inherit from project dM).

## Test plan
- [x] `mvn validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)