### PR TITLE
chore(ci): align Java matrix to 11-only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,15 +39,14 @@ jobs:
           - temurin
           - zulu
         java-version:
-          - 17
-          - 21
+          - 11
         include:
           - platform: windows-latest
             java-distribution: adopt-hotspot
-            java-version: 17
+            java-version: 11
           - platform: macos-latest
             java-distribution: adopt-hotspot
-            java-version: 17
+            java-version: 11
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Summary

uPortal-start deploys on **Java 11**, but CI was testing exclusively on Java 17/21 — which gave false confidence and risked a dependency compiled for Java 17+ bytecode slipping through and breaking at runtime on the deployed JVM.

Other portlets already aligned: AnnouncementsPortlet, NewsReaderPortlet, resource-server. This brings the rest of the fleet into the same matrix shape.

## Test plan
- [x] Diff is trivial (YAML-only); portlet build unchanged
- [ ] CI run exercises the Java 11 matrix on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)