### PR TITLE
chore: bump uportal-portlet-parent 47 → 48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>47</version>
+    <version>48</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -50,8 +50,6 @@
   </issueManagement>
 
   <properties>
-    <!-- Override parent's logback 1.3.12; this portlet tracks logback 1.5.x. -->
-    <logbackVersion>1.5.16</logbackVersion>
     <spring.version>4.3.30.RELEASE</spring.version>
     <uportal-libs.version>5.17.2</uportal-libs.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
@@ -72,7 +70,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>${logbackVersion}</version>
       <scope>runtime</scope>
     </dependency>
 


### PR DESCRIPTION
## Summary

Parent v48 bumps `logback-classic` 1.3.12 → 1.5.32 for security fixes.

This portlet was overriding to 1.5.16 locally. Dropping the `<logbackVersion>` property and the `<version>${logbackVersion}</version>` line on `logback-classic` so it inherits the parent's newer pin.

## Compatibility

- **Java 11 baseline**: logback 1.5.x requires Java 11+. Matches this portlet's deployment target.
- **SLF4J**: unchanged 2.x binding.
- **`javax.servlet` → `jakarta.servlet`**: only affects `logback-access`, which this portlet does not use.

## Test plan
- [x] `mvn validate` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)