### PR TITLE
chore: tighten renovate pins (jaxb, plexus-archiver; broaden spring/hibernate)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,37 +14,36 @@
       "description": "uPortal runs JSR-286 (Portlet API 2.0). Portlet API 3.x (JSR-362) is a different container contract and is not supported."
     },
     {
-      "matchPackageNames": [
-        "org.springframework:spring-framework-bom",
-        "org.springframework:spring-aop",
-        "org.springframework:spring-beans",
-        "org.springframework:spring-context",
-        "org.springframework:spring-context-support",
-        "org.springframework:spring-core",
-        "org.springframework:spring-jdbc",
-        "org.springframework:spring-orm",
-        "org.springframework:spring-test",
-        "org.springframework:spring-tx",
-        "org.springframework:spring-web",
-        "org.springframework:spring-webmvc",
-        "org.springframework:spring-webmvc-portlet",
-        "org.springframework.data:spring-data-jpa"
+      "matchPackagePrefixes": [
+        "org.springframework:",
+        "org.springframework.data:"
       ],
       "allowedVersions": "< 5.0",
-      "description": "This portlet is pinned to Spring Framework 4.3.x. Next-major bumps require a coordinated migration."
+      "description": "This portlet is pinned to Spring Framework 4.3.x. Spring 5+ requires a coordinated migration; Spring 6+ additionally needs Jakarta EE + Java 17+."
+    },
+    {
+      "matchPackagePrefixes": [
+        "org.hibernate:",
+        "org.hibernate.orm:"
+      ],
+      "allowedVersions": "< 4.0",
+      "description": "Pinned to Hibernate 3.6.x. Hibernate 4+ needs Spring 5+; Hibernate 6+ additionally requires Jakarta EE and Java 17+."
     },
     {
       "matchPackageNames": [
-        "org.hibernate:hibernate-core",
-        "org.hibernate:hibernate-ehcache",
-        "org.hibernate:hibernate-entitymanager",
-        "org.hibernate:hibernate-jpamodelgen",
-        "org.hibernate:hibernate-tools",
-        "org.hibernate:hibernate-validator",
-        "org.hibernate.orm:hibernate-core"
+        "com.sun.xml.bind:jaxb-impl",
+        "jakarta.xml.bind:jakarta.xml.bind-api",
+        "org.glassfish.jaxb:jaxb-runtime"
       ],
-      "allowedVersions": "< 4.0",
-      "description": "Pinned to Hibernate 3.6.x. Later majors require Jakarta EE or Java 17+, neither of which match this portlet."
+      "allowedVersions": "< 3.0",
+      "description": "jaxb-impl 2.x and jakarta.xml.bind-api/jaxb-runtime 2.x are the last releases that preserve the javax.xml.bind.* package namespace. 3+ moves to the jakarta.xml.bind package as part of Jakarta EE 9+, which this portlet is not migrating to yet."
+    },
+    {
+      "matchPackageNames": [
+        "org.codehaus.plexus:plexus-archiver"
+      ],
+      "allowedVersions": "< 4.10.0",
+      "description": "plexus-archiver 4.10+ requires a newer commons-io (BoundedInputStream.builder()) than the one bundled with maven-war-plugin 3.4.0 (pinned by uportal-portlet-parent). Revisit once the parent bumps maven-war-plugin to 3.5.x+."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two new rules + broaden two existing ones to match the pattern we've standardized across the fleet.

### New rules
| Rule | Why | Blocks |
|---|---|---|
| `com.sun.xml.bind:jaxb-impl`, `jakarta.xml.bind:jakarta.xml.bind-api`, `org.glassfish.jaxb:jaxb-runtime` `< 3.0` | 2.x preserves the `javax.xml.bind.*` package namespace; 3+ moves to `jakarta.xml.bind` as part of Jakarta EE 9+, which this portlet is not migrating to yet. | #135 |
| `org.codehaus.plexus:plexus-archiver < 4.10.0` | 4.10+ calls `commons-io`'s `BoundedInputStream.builder()`, which doesn't exist in the `commons-io` bundled with `maven-war-plugin:3.4.0` (pinned by parent). Same pin added to [Webproxy](https://github.com/uPortal-Project/WebproxyPortlet/pull/264) and [basiclti](https://github.com/uPortal-Project/basiclti-portlet/pull/60). | #130 |

### Broadened rules
- **Spring** — `matchPackageNames` → `matchPackagePrefixes: ["org.springframework:", "org.springframework.data:"]`. Catches future Spring artifacts automatically instead of hand-maintaining a list.
- **Hibernate** — `matchPackageNames` → `matchPackagePrefixes: ["org.hibernate:", "org.hibernate.orm:"]`. Catches the Hibernate 6+ artifact-relocation variants (`hibernate-processor`, etc.) in addition to current names.

### After merge

Renovate will close its own PRs on the next rebase cycle:
- #91 (hibernate-orm:hibernate-core v7)
- #130 (plexus-archiver 4.11)
- #135 (jaxb-impl v4)

The **Dependabot** PRs (#70 hibernate-core v5.4, #80 hibernate-validator v6.0, #102 spring-core v5.2) are not affected by `renovate.json` and need manual closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)