### PR TITLE
chore: bump parent to v49 and inherit license-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>48</version>
+    <version>49</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -277,28 +277,6 @@
             <version>4.0.3</version>
           </dependency>
         </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>com.mycila.maven-license-plugin</groupId>
-        <artifactId>maven-license-plugin</artifactId>
-        <configuration>
-          <basedir>${basedir}</basedir>
-          <header>${jasig-short-license-url}</header>
-
-          <aggregate>true</aggregate>
-          <strictCheck>true</strictCheck>
-          <excludes>
-            <exclude>LICENSE</exclude>
-            <exclude>NOTICE</exclude>
-            <exclude>.idea/**</exclude> <!-- Exclude intelliJ files -->
-            <exclude>overlays/**</exclude> <!-- Exclude intelliJ files -->
-            <exclude>.gitignore</exclude>
-          </excludes>
-          <mapping>
-            <crn>XML_STYLE</crn>
-            <tag>DYNASCRIPT_STYLE</tag>
-          </mapping>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

Bumps to parent v49 ([release notes](https://github.com/uPortal-Project/uportal-portlet-parent/releases/tag/uportal-portlet-parent-49)) and drops the entire local `license-maven-plugin` block — every exclude and mapping was redundant with what the parent provides.

## Why

The local block declared the legacy `com.mycila.maven-license-plugin` coordinate without a version pin, and listed five excludes (`LICENSE`, `NOTICE`, `.idea/**`, `overlays/**`, `.gitignore`) and two mappings (`crn`, `tag`) that parent v49 provides. With v49 in place, the entire `<plugin>` block becomes pure boilerplate.

Part of the post-v49 fleet sweep — see also #105 (CoursesPortlet), #347 (AnnouncementsPortlet), #65 (basiclti-portlet).

## Changes

`pom.xml`: parent `48` → `49`; delete the full 22-line `com.mycila.maven-license-plugin` block.


## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [x] `mvn license:check` — green against inherited config
- [ ] CI on Java 11 matrix
