### PR TITLE
chore: bump parent v49 → v50 for plexus-archiver CVE fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>50</version>
+    <version>51</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -92,8 +92,8 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>49</version>
+    <version>50</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Bookmark.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Bookmark.java
@@ -18,9 +18,9 @@
  */
 package edu.wisc.my.portlets.bookmarks.domain;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * A bookmark tracks a URL and if the URL should be opened in a new window.

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/BookmarkSet.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/BookmarkSet.java
@@ -18,9 +18,9 @@
  */
 package edu.wisc.my.portlets.bookmarks.domain;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * The root folder for a tree of bookmarks, adds an owner field to the object to associate

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Entry.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Entry.java
@@ -21,9 +21,9 @@ package edu.wisc.my.portlets.bookmarks.domain;
 import java.io.Serializable;
 import java.util.Date;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * An Entry is the base object that may in a bookmarks hierarchy. It is a stand alone object

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Folder.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Folder.java
@@ -31,9 +31,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import edu.wisc.my.portlets.bookmarks.domain.compare.DefaultBookmarksComparator;
 import edu.wisc.my.portlets.bookmarks.domain.support.IntegerSetThreadLocal;

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Preferences.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Preferences.java
@@ -21,9 +21,9 @@ package edu.wisc.my.portlets.bookmarks.domain;
 import java.io.Serializable;
 import java.util.Date;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * This class contains preferences (mainly user interface/experiance related) for a BookmarkSet.

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/compare/DefaultBookmarksComparator.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/compare/DefaultBookmarksComparator.java
@@ -21,7 +21,7 @@ package edu.wisc.my.portlets.bookmarks.domain.compare;
 import java.io.Serializable;
 import java.util.Comparator;
 
-import org.apache.commons.lang.builder.CompareToBuilder;
+import org.apache.commons.lang3.builder.CompareToBuilder;
 
 import edu.wisc.my.portlets.bookmarks.domain.Bookmark;
 import edu.wisc.my.portlets.bookmarks.domain.Entry;

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/support/IdPathInfo.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/support/IdPathInfo.java
@@ -20,9 +20,9 @@ package edu.wisc.my.portlets.bookmarks.domain.support;
 
 import edu.wisc.my.portlets.bookmarks.domain.Entry;
 import edu.wisc.my.portlets.bookmarks.domain.Folder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * <p>IdPathInfo class.</p>

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/web/EditBookmarksController.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/web/EditBookmarksController.java
@@ -37,7 +37,7 @@ import edu.wisc.my.portlets.bookmarks.domain.validation.CollectionValidator;
 import edu.wisc.my.portlets.bookmarks.domain.validation.FolderValidator;
 import edu.wisc.my.portlets.bookmarks.web.support.BookmarkSetRequestResolver;
 import edu.wisc.my.portlets.bookmarks.web.support.ViewConstants;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
Bumps to [uportal-portlet-parent:50](https://github.com/uPortal-Project/uportal-portlet-parent/releases/tag/uportal-portlet-parent-50), which patches **CVE-2023-37460** (plexus-archiver Arbitrary File Creation in AbstractUnArchiver, CVSS 8.1 HIGH) by bumping its bundled `maven-war-plugin` 3.4.0 → 3.5.1 (which carries plexus-archiver 4.10.4, patched).

Real-world risk for portlet builds is low — we use plexus-archiver to *create* WARs, not extract untrusted archives — but the parent shouldn't ship a known-vulnerable transitive by default.

## Test plan

- [x] `mvn clean install license:check -Dgpg.skip=true` — green
- [ ] CI on Java 11 matrix