### PR TITLE
fix: remove dead Delicious-fetch path and drop commons-httpclient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,24 +74,6 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
-      <type>jar</type>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/CollectionFolder.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/CollectionFolder.java
@@ -18,27 +18,8 @@
  */
 package edu.wisc.my.portlets.bookmarks.domain;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpException;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.methods.GetMethod;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 import edu.wisc.my.portlets.bookmarks.domain.support.IntegerSetThreadLocal;
 
@@ -50,8 +31,6 @@ import edu.wisc.my.portlets.bookmarks.domain.support.IntegerSetThreadLocal;
  */
 public class CollectionFolder extends Entry implements CollapsibleEntry {
     private static final long serialVersionUID = 1L;
-    
-	private static Logger log = LoggerFactory.getLogger(CollectionFolder.class);
 
     private static IntegerSetThreadLocal equalsVisitedFolder = new IntegerSetThreadLocal();
     private static IntegerSetThreadLocal hashCodeVisitedFolder = new IntegerSetThreadLocal();
@@ -87,71 +66,6 @@ public class CollectionFolder extends Entry implements CollapsibleEntry {
         this.minimized = minimized;
     }
     
-    /**
-     * Returns an immutable sorted view of the values of the children Map. The sorting is done
-     * using the current childComparator. Warning, this is has a time cost of 2n log(n)
-     * on every call.
-     *
-     * @return An immutable sorted view of the folder's children.
-     */
-    public List<Entry> getSortedChildren() {
-    	List<Entry> children = new ArrayList<Entry>();
-    	log.debug("children: " + children.size());
-
-		HttpClient client = new HttpClient();
-		GetMethod get = null;
-
-		try {
-
-			log.debug("getting url " + url);
-			get = new GetMethod(url);
-			int rc = client.executeMethod(get);
-			if (rc != HttpStatus.SC_OK) {
-				log.error("HttpStatus:" + rc);
-			}
-
-			DocumentBuilderFactory domBuilderFactory = DocumentBuilderFactory
-				.newInstance();
-			DocumentBuilder builder = domBuilderFactory.newDocumentBuilder();
-
-			InputStream in = get.getResponseBodyAsStream();
-			builder = domBuilderFactory.newDocumentBuilder();
-			Document doc = builder.parse(in);
-			get.releaseConnection();
-			
-			Element e = (Element) doc.getElementsByTagName("rdf:RDF").item(0);
-			log.debug("got root " + e);
-			NodeList n = e.getElementsByTagName("item");
-			log.debug("found items " + n.getLength());
-			for (int i = 0; i < n.getLength(); i++) {
-				Bookmark bookmark = new Bookmark();
-				Element l = (Element) n.item(i);
-				bookmark.setName(((Element) l.getElementsByTagName("title").item(0)).getTextContent());
-				bookmark.setUrl(((Element) l.getElementsByTagName("link").item(0)).getTextContent());
-				if (l.getElementsByTagName("description").getLength() > 0) {
-					bookmark.setNote(((Element) l.getElementsByTagName("description").item(0)).getTextContent());
-				}
-				children.add(bookmark);
-				log.debug("added bookmark " + bookmark.getName() + " " + bookmark.getUrl());
-			}
-
-		} catch (HttpException e) {
-			log.error("Error parsing delicious", e);
-		} catch (IOException e) {
-			log.error("Error parsing delicious", e);
-		} catch (ParserConfigurationException e) {
-			log.error("Error parsing delicious", e);
-		} catch (SAXException e) {
-			log.error("Error parsing delicious", e);
-		} finally {
-			if (get != null)
-				get.releaseConnection();
-		}
-
-    	log.debug("children: " + children.size());
-    	return children;
-    }
-
 	/**
 	 * <p>Getter for the field <code>url</code>.</p>
 	 *


### PR DESCRIPTION
Closes Dependabot CVE-2012-5783 (commons-httpclient SSL hostname verification).

## Background

`CollectionFolder.getSortedChildren()` fetched and parsed an RDF feed from **Delicious**, the social bookmarking service. Delicious **shut down in 2017** (after a series of acquisitions and partial sales since Yahoo's 2005 purchase). The fetch URL no longer resolves — every call has been silently failing for years.

Other markers in the class corroborate that this code path was never fully wired up:

- `getChildren()` returns `new HashMap<>()` with a `// TODO` comment
- All four exception handlers log `'Error parsing delicious'`
- The override is only on `CollectionFolder`; the parent `Folder.getSortedChildren()` handles the empty-children case correctly

## Changes

`src/main/java/.../domain/CollectionFolder.java`:
- Remove the Delicious-fetching `getSortedChildren()` override (~50 lines).
- Remove now-unused imports: `commons-httpclient`, `javax.xml.parsers`, `org.w3c.dom`, `org.xml.sax`, `slf4j`.
- Remove the now-unused static `Logger log` field.

`pom.xml`:
- Remove the `commons-httpclient:3.1` `<dependency>` block.

## Why not migrate to httpclient 4.x?

Considered, but the migration target is meaningless work — the URL doesn't resolve and the page format Delicious served (RDF over HTTP) was unique to that service. Keeping a working HTTP-fetch path for a defunct service is worse than deleting it. If a future requirement re-introduces external feed fetching for collection folders, the right call is to design the new feed contract from scratch and pull in the modern `org.apache.httpcomponents:httpclient` (already provided by parent v50 dM) on a clean build of that feature.

## Test plan

- [x] `mvn clean install -Dgpg.skip=true` — green
- [ ] CI on Java 11 matrix