### PR TITLE
chore: bump parent v49 -> v51 and migrate commons-lang -> commons-lang3

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,11 +17,12 @@ under the License.
 
 This project includes:
   AntLR under BSD License
-  Apache Commons Collections under Apache License, Version 2.0
+  Apache Commons Codec under Apache-2.0
+  Apache Commons Lang under Apache-2.0
   Bean Validation API under Apache License 2.0
   Bookmarks Portlet under Apache License Version 2.0
-  Codec under Apache License, Version 2.0
   Commons Lang under The Apache Software License, Version 2.0
+  commons-collections under Apache License, Version 2.0
   dom4j under BSD License
   ehcache under The Apache Software License, Version 2.0
   Ehcache Core under The Apache Software License, Version 2.0
@@ -31,7 +32,6 @@ This project includes:
   Hibernate Core under GNU Lesser General Public License
   Hibernate Validator under Apache License, Version 2.0
   HSQLDB under HSQLDB License
-  HttpClient under Apache License
   Jakarta Activation under EDL 1.0
   Jakarta XML Binding API under Eclipse Distribution License - v 1.0
   JASYPT: Java Simplified Encryption under The Apache Software License, Version 2.0
@@ -40,15 +40,14 @@ This project includes:
   JavaBeans Activation Framework API jar under CDDL/GPLv2+CE
   javax.annotation API under CDDL + GPLv2 with classpath exception
   jaxb-api under CDDL 1.1 or GPL2 w/ CPE
-  JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
+  JCL 1.2 implemented over SLF4J under Apache-2.0
   JPA 2.0 API under Sun Binary Code License
   jstl under Commons Development and Distribution License, Version 1.0
   JUnit under Eclipse Public License 1.0
-  Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
-  Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
+  Logback Classic Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
+  Logback Core Module under Eclipse Public License - v 2.0 or GNU Lesser General Public License
   Old JAXB Runtime under Eclipse Distribution License - v 1.0
-  servlet-api under Commons Development and Distribution License, Version 1.0
-  SLF4J API Module under MIT License
+  SLF4J API Module under MIT
   Spring AOP under Apache License, Version 2.0
   Spring Beans under Apache License, Version 2.0
   Spring Context under Apache License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>50</version>
+    <version>51</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
@@ -74,8 +74,8 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.jasig.portlet</groupId>
     <artifactId>uportal-portlet-parent</artifactId>
-    <version>49</version>
+    <version>50</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Bookmark.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Bookmark.java
@@ -18,9 +18,9 @@
  */
 package edu.wisc.my.portlets.bookmarks.domain;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * A bookmark tracks a URL and if the URL should be opened in a new window.

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/BookmarkSet.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/BookmarkSet.java
@@ -18,9 +18,9 @@
  */
 package edu.wisc.my.portlets.bookmarks.domain;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * The root folder for a tree of bookmarks, adds an owner field to the object to associate

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Entry.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Entry.java
@@ -21,9 +21,9 @@ package edu.wisc.my.portlets.bookmarks.domain;
 import java.io.Serializable;
 import java.util.Date;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * An Entry is the base object that may in a bookmarks hierarchy. It is a stand alone object

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Folder.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Folder.java
@@ -31,9 +31,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import edu.wisc.my.portlets.bookmarks.domain.compare.DefaultBookmarksComparator;
 import edu.wisc.my.portlets.bookmarks.domain.support.IntegerSetThreadLocal;

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Preferences.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/Preferences.java
@@ -21,9 +21,9 @@ package edu.wisc.my.portlets.bookmarks.domain;
 import java.io.Serializable;
 import java.util.Date;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * This class contains preferences (mainly user interface/experiance related) for a BookmarkSet.

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/compare/DefaultBookmarksComparator.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/compare/DefaultBookmarksComparator.java
@@ -21,7 +21,7 @@ package edu.wisc.my.portlets.bookmarks.domain.compare;
 import java.io.Serializable;
 import java.util.Comparator;
 
-import org.apache.commons.lang.builder.CompareToBuilder;
+import org.apache.commons.lang3.builder.CompareToBuilder;
 
 import edu.wisc.my.portlets.bookmarks.domain.Bookmark;
 import edu.wisc.my.portlets.bookmarks.domain.Entry;

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/domain/support/IdPathInfo.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/domain/support/IdPathInfo.java
@@ -20,9 +20,9 @@ package edu.wisc.my.portlets.bookmarks.domain.support;
 
 import edu.wisc.my.portlets.bookmarks.domain.Entry;
 import edu.wisc.my.portlets.bookmarks.domain.Folder;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * <p>IdPathInfo class.</p>

--- a/src/main/java/edu/wisc/my/portlets/bookmarks/web/EditBookmarksController.java
+++ b/src/main/java/edu/wisc/my/portlets/bookmarks/web/EditBookmarksController.java
@@ -37,7 +37,7 @@ import edu.wisc.my.portlets.bookmarks.domain.validation.CollectionValidator;
 import edu.wisc.my.portlets.bookmarks.domain.validation.FolderValidator;
 import edu.wisc.my.portlets.bookmarks.web.support.BookmarkSetRequestResolver;
 import edu.wisc.my.portlets.bookmarks.web.support.ViewConstants;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
Release-prep PR for BookmarksPortlet 1.3.1, aligning with the fleet-wide v51 + lang3 wave.

## Summary

Three commits, each independently buildable:

1. **Parent v49 -> v50**: picks up `maven-war-plugin` 3.5.1 for plexus-archiver CVE-2023-37460.
2. **Parent v50 -> v51 + commons-lang -> commons-lang3**: parent v51 dropped legacy `commons-lang` from dM and added `commons-lang3` + `commons-text`. Source migration (8 files) is the standard package rename — `org.apache.commons.lang.*` to `org.apache.commons.lang3.*`. No StringEscapeUtils usage in this repo, so no commons-text needed.
3. **Regenerate NOTICE**: drops `HttpClient` + `Apache Commons Collections` (both gone post-#145), adds `Apache Commons Lang`, picks up Logback EPL v1 -> v2 from parent v51's logback bump. `mvn notice:check` now passes.

## Why combined

Splitting these would require either pinning a transitional `commons-lang` dM entry (parent v51 dropped it) or shipping a CI-broken intermediate state. The combined PR is the minimum that keeps `master` green at every commit.

PR #145 (Delicious removal + commons-httpclient drop) merged ahead of this; the rebase resolved the resulting NOTICE conflict cleanly.

## Test plan

- [x] `mvn -B clean install` passes locally on Java 11
- [x] `mvn notice:check` passes
- [x] `mvn license:check` passes
- [ ] CI green
- [ ] Post-merge: `mvn release:clean release:prepare release:perform` for 1.3.1